### PR TITLE
Update compare.html to improve layout

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -5,8 +5,9 @@ weight: 9
 <style type="text/css">
 	cb-card { font-size: 30%; cursor: pointer; }
 	tbody, thead { display: block }
-	tbody { max-height: 460px; overflow: auto }
-	#results { overflow: auto; }
+	tbody { overflow: auto }
+	#results { max-height: 100vh; overflow: auto; }
+	.content { max-width: none; }
 </style>
 <div class="panel panel-warning">
 	<div class="panel-heading">


### PR DESCRIPTION
Setting max-height on the tbody when it's wider than the content area means that on non-touch devices, you have to scroll all the way to the right in #results before you can access the vertical scrollbar of the table. Removed tbody's max-height and set it on the #results fieldset instead. Also, changed it from static 460px to 100vh (100% of viewport height).
There is one drawback to this - now the top row no longer stays in view when scrolling down, since the tbody now has whatever height is required for its contents, it won't carry its own scrollbar. I couldn't find a way to get both at the same time.

I also removed max-width from .content to take advantage of available space on larger displays, since the table is often more cards wide than will fit in 800px - nobody wants to have to scroll horizontally. As this feature is currently designed, it may not always be possible to avoid horizontal scrolling, but now a large screen will avoid it when possible, or at least minimize it otherwise, rather than just having a large swath of whitespace on both sides.