### PR TITLE
Add min-width to .deck .item

### DIFF
--- a/javascript/share-your-deck.js
+++ b/javascript/share-your-deck.js
@@ -201,7 +201,7 @@ define(['cartoon-battle', 'cartoon-battle/util', 'cartoon-battle/Analysis'], fun
         item.appendChild((function (btn) {
             btn.className = 'btn btn-danger btn-xs';
             btn.onclick = function () { remove(this.parentNode); };
-            btn.textContent = ' Remove';
+            btn.appendChild(document.createElement('span')).appendChild(document.createTextNode(' Remove ')).parentNode.className = 'label';
 
             btn.insertBefore(document.createElement('span'), btn.firstChild).className = 'glyphicon glyphicon-trash';
 
@@ -211,7 +211,7 @@ define(['cartoon-battle', 'cartoon-battle/util', 'cartoon-battle/Analysis'], fun
         item.appendChild((function (btn) {
             btn.className = 'btn btn-primary btn-xs pull-right';
             btn.onclick = function () { edit(this.parentNode.querySelector('cb-card')); };
-            btn.textContent = ' Edit ';
+            btn.appendChild(document.createElement('span')).appendChild(document.createTextNode(' Edit ')).parentNode.className = 'label';
 
             btn.insertBefore(document.createElement('span'), btn.firstChild).className = 'glyphicon glyphicon-edit';
 

--- a/share-your-deck.html
+++ b/share-your-deck.html
@@ -12,6 +12,7 @@ weight: 8
         display: inline-block;
         float: none;
         width: 24%;
+        min-width: 140px;
     }
     #suggested-cards cb-card {
         cursor: pointer;

--- a/share-your-deck.html
+++ b/share-your-deck.html
@@ -37,6 +37,11 @@ weight: 8
     .panel-footer {
         margin-bottom: 3em;
     }
+    @media (max-width: 640px) {
+        .deck .btn .label {
+            display: none;
+        }
+    }
     hr { clear: both; }
 </style>
 


### PR DESCRIPTION
Added a min-width of 140px to prevent card images from overlapping on displays narrower than 950px