### PR TITLE
Fix for Issue #7

### DIFF
--- a/css/card.css
+++ b/css/card.css
@@ -123,7 +123,6 @@ cb-card cb-skills cb-value {
     text-align: center;
 }
 cb-card cb-skills cb-value[target]:before {
-    background-image: url({{ site.images_cdn }}deck/skills/skill_special.png);
     background-size: 100% 100%;
     display: block;
     width: 1.2em;
@@ -132,8 +131,11 @@ cb-card cb-skills cb-value[target]:before {
     left: 0;
     content: ""
 }
+cb-card cb-skills cb-value[target="show"]:before {
+    background-image: url({{ site.images_cdn }}deck/skills/skill_targetIP.png);
+}
 cb-card cb-skills cb-value[target="trait"]:before {
-    filter: grayscale(100%);
+    background-image: url({{ site.images_cdn }}deck/skills/skill_special.png);
 }
 
 cb-card cb-skills {


### PR DESCRIPTION
It looks like the site owner will need to edit the skill_targetIP.png that I provided by extending the image's background to the right and down in order to double both dimensions (to add whitespace without resizing the icon itself) in order to make it display properly. (I would do this myself, but the only image editing program I have is MSPaint, which does not preserve PNG transparency.)
Then the site owner will need to upload the image to their repository with the name "skill_targetIP.png", and then this code change should correctly display the new image on "only targets show" skills.