### PR TITLE
add new skills to the combo recipes?  

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-local:
-	jekyll serve
- 
 all:
 	docker run --rm -v $(shell pwd):/srv/jekyll --net szg_default -it -p 4000 \
 	    --label 'traefik.http.routers.cartoon-battle.rule=Host("www.cartoon-battle.dev")' \
 	    jekyll/jekyll jekyll serve --watch 
+
+local:
+	jekyll serve
+ 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+local:
+	jekyll serve
+ 
 all:
 	docker run --rm -v $(shell pwd):/srv/jekyll --net szg_default -it -p 4000 \
 	    --label 'traefik.http.routers.cartoon-battle.rule=Host("www.cartoon-battle.dev")' \

--- a/_data/values.yml
+++ b/_data/values.yml
@@ -43,6 +43,9 @@ skills:
     hijack: Hijack
     bodyguard: Bodyguard
     give: Give
+    bunker: Bunker
+    burn: Burn
+    enlarge: Enlarge
 
 traits: [addicted, armed, artistic, athletic, disguised, drunk, educated, fighter, hyper, rich, musical, animal]
 


### PR DESCRIPTION
really just want to be able to see the new icons on the cards

+    bunker: Bunker
+    burn: Burn
+    enlarge: Enlarge

need to host my own copy to actually figure out how this works, but, this is a start

installing jekyll and running
$ jekyll serve
not quite working; there are CORS issue as it still wants to point to cartoon-battle.narzekasz.pl, eg

XMLHttpRequest at 'https://cartoon-battle.narzekasz.pl/assets/cards_mythic.xml' from origin 'http://localhost:4000' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header has a value 'https://cartoon-battle.cards' that is not equal to the supplied origin.

and also not clear how to add hosting of these:
GET https://cartoon-battle.narzekasz.pl/deck/skills/skill_bunker.png 404
GET https://cartoon-battle.narzekasz.pl/deck/skills/skill_burn.png 404
GET https://cartoon-battle.narzekasz.pl/deck/skills/skill_enlarge.png 404

i'll can attach the icons themselves here if that helps.